### PR TITLE
Remove unused "rows" argument to peek()

### DIFF
--- a/scripts/lsd-setup-update.sh
+++ b/scripts/lsd-setup-update.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# 
+# Builds a .tar.bz2 source package, and makes it the default in
+# lsd-setup's Makefile. Assumes (but checks) that lsd-setup has
+# been checked out in ../lsd-setup.
+#
+
+test -f setup.py || { echo "This script must be run from LSD's base directory (the one containing setup.py)"; exit -1; }
+test -d ../lsd-setup/var/pkg/repo || { echo "lsd-setup, with source repository, must be checked out in ../lsd-setup"; exit -1; }
+test ! -d var/pkg || { echo "You must run this package from LSD, not lsd-setup's base directory"; exit -1; }
+
+PYTHONVER=`python --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2`
+test x"$PYTHONVER" == x"2.7" || { echo "Python 2.7 required. Your Python is reporting $PYTHONVER."; exit -1; }
+
+rm -rf dist && \
+python setup.py sdist --format bztar && \
+cp dist/* ../lsd-setup/var/pkg/repo || exit -1
+
+LSDPKG=$(basename $(ls dist/*.bz2) .tar.bz2)
+sed "s/LSDPKG=.*/LSDPKG=$LSDPKG/" ../lsd-setup/var/pkg/scripts/Makefile > ../lsd-setup/var/pkg/scripts/Makefile.tmp && \
+	mv ../lsd-setup/var/pkg/scripts/Makefile.tmp ../lsd-setup/var/pkg/scripts/Makefile
+
+echo "lsd-setup Makefile updated to LSDPKG=$LSDPKG:"
+echo "======================================================="
+(cd ../lsd-setup && git diff)
+echo "======================================================="
+echo "Press ENTER to continue..."
+read
+(cd ../lsd-setup && git commit -a -e -m "Adding $LSDPKG")

--- a/src/benchmarks.txt
+++ b/src/benchmarks.txt
@@ -1,0 +1,44 @@
+workers, readers, wallclock, querytime
+
+time ./lsd-query --bounds='rectangle(100, -30, 110, 0)' --format=null 'select ra, dec, filterid, mjd_obs from ps1_det, sdss(matchedto=ps1_det, outer)'
+12	2	2:39	155
+12	3	3:34
+12	-	3:19
+12	1	2:43
+12	1	2:52
+
+time ./lsd-query --bounds=rectangle(100, -30, 110, 0) --format=null select ra, dec, filterid, mjd_obs from ps1_det, sdss(matchedto=ps1_det)
+12	2	1:47	103
+12	24	2:10	126
+12	24	2:15	130
+12	2	1:50	106
+12	1	1:53	108
+12	1	1:51	106
+24	1	1:41	96
+24	2	1:39	95
+
+time ./lsd-query --bounds='rectangle(100, -30, 110, 0)' --format=null 'select ra, dec, filterid, mjd_obs from ps1_obj, ps1_det, sdss(matchedto=ps1_obj)'
+24	2	4:26	259
+24	1	4:28	261
+24	12	4:23	256
+12	12	5:35	329
+12	2	5:37	331
+
+time ./lsd-query --bounds='rectangle(100, -30, 110, 0)' --format=null 'select ra, dec, filterid, mjd_obs from ps1_obj, ps1_det'
+12	2	4:14	243
+12	1	4:29	263
+12	12	4:57	292
+
+time ./lsd-query --bounds='rectangle(100, -30, 110, 0)' --format=null 'select ra, dec from averages'
+12	1	0:15	13
+12	12	0:28	26
+24	24	0:23	21
+24	24	0:26	24
+24	2	0:16	14
+
+time ./lsd-query --bounds='rectangle(100, -30, 130, 0)' --format=null 'select ra, dec from averages'
+24	2	0:33	30
+24	24	0:43	41
+24	24	0:49	47
+24	2	0:33	31
+24	1	0:27	25

--- a/src/lsd-manager
+++ b/src/lsd-manager
@@ -4,14 +4,15 @@ import multiprocessing
 import logging
 import threading
 import sys, os
-from lsd.pyrpc import PyRPCServer
+import time
+from lsd.pyrpc import PyRPCServer, AllowAllAccessControl
 from lsd.tui import *
 
 ########### Simple check-in server
 
 logger = logging.getLogger()
 
-class ActiveWorkerManager:
+class WorkerManager:
 	_lock = None
 	_pools = None
 	
@@ -21,29 +22,87 @@ class ActiveWorkerManager:
 		self._maxcores = maxcores
 		logger.info("LSD manager started, maxcores=%d" % (self._maxcores,))
 
-	def __connect__(self, client_address):
+	def register_workers(self, nworkers, _context):
+		client_address = _context.client_address
 		with self._lock:
 			assert client_address not in self._pools
 			self._pools[client_address] = 1
-			logger.info("%s:%s connected (%d active connections)" % (client_address[0], client_address[1], len(self._pools)))
+			cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
+			logger.info("[%s] [WorkerManager] begun managing (%d active connections)" % (cli_info, len(self._pools)))
 
-	def __disconnect__(self, client_address):
+	def __disconnect__(self, _context):
 		with self._lock:
-			del self._pools[client_address]
-			logger.info("%s:%s disconnected (%d active connections)" % (client_address[0], client_address[1], len(self._pools)))
+			if _context.client_address not in self._pools:
+				return
+			del self._pools[_context.client_address]
+			cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
+			logger.info("[%s] [WorkerManager] stopped managing (%d active connections)" % (cli_info, len(self._pools)))
 
 	def nworkers(self):
 		""" Return the number of workers the client should have active """
-		#ncores = multiprocessing.cpu_count()
 		ncores = self._maxcores
 
 		with self._lock:
 			nworkers = int(float(ncores) / len(self._pools))
-		
+
 		if nworkers == 0:
 			nworkers = 1
 
 		return nworkers
+
+class AccessSync:
+	_lock = None
+	_leases = None
+
+	def __init__(self, maxleases):
+		self._lock = threading.Lock()
+		self._leases = threading.BoundedSemaphore(maxleases)
+		self._leases_expire = dict()
+		self._maxleases = maxleases
+
+		self._lease_expiration_thread = threading.Thread(target=self._expire_leases)
+		self._lease_expiration_thread.daemon = True
+		self._lease_expiration_thread.start()
+
+		logger.info("AccessSync manager started, maxleases=%d" % (self._maxleases,))
+
+	def obtain_access_lease(self, fn, _context):
+		cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
+		logger.info("[%s] [AccessSync] requested lease for %s" % (cli_info, fn))
+
+		self._leases.acquire()
+		with self._lock:
+			self._leases_expire[_context.client_address] = time.time() + 10
+
+		logger.info("[%s] [AccessSync] acquired lease for %s" % (cli_info, fn))
+		return True
+
+	def relinquish_access_lease(self, fn, _context):
+		with self._lock:
+			try:
+				del self._leases_expire[_context.client_address]
+				self._leases.release()
+			except KeyError:
+				pass
+
+		cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
+		logger.info("[%s] [AccessSync] released lease for %s" % (cli_info, fn))
+
+		return True
+
+	def __disconnect__(self, _context):
+		self.relinquish_access_lease(None, _context)
+
+	def _expire_leases(self):
+		while True:
+			with self._lock:
+				t = time.time()
+				for lease, exptime in self._leases_expire.items():
+					if exptime > t:
+						continue
+					self._leases.release()
+					del self._leases_expire[lease]
+			time.sleep(1)
 
 def usage():
 	print "Usage: %s --quiet <max_cores>" % sys.argv[0]
@@ -52,6 +111,8 @@ if __name__ == "__main__":
 	optlist, (max_cores,) = tui_getopt('q', ['quiet'], 1, usage, stdopts=False)
 
 	# Instantiate a server
-	server = PyRPCServer("localhost", 9029)
-	server.register_instance(ActiveWorkerManager(int(max_cores)))
+	server = PyRPCServer("localhost", 9030)
+	server.register_instance(AllowAllAccessControl())
+	server.register_instance(WorkerManager(int(max_cores)))
+	server.register_instance(AccessSync(1))
 	server.serve_forever()

--- a/src/lsd-manager
+++ b/src/lsd-manager
@@ -5,7 +5,8 @@ import logging
 import threading
 import sys, os
 import time
-from lsd.pyrpc import PyRPCServer, AllowAllAccessControl
+from collections import defaultdict
+from lsd.pyrpc import Server as PyRPCServer, AllowAllAccessControl
 from lsd.tui import *
 
 ########### Simple check-in server
@@ -50,69 +51,114 @@ class WorkerManager:
 
 		return nworkers
 
-class AccessSync:
-	_lock = None
-	_leases = None
+def digest(fn):
+	import hashlib
+	return hashlib.md5(fn).hexdigest()
 
+class AccessSync:
+	"""
+	Give leases for file access to clients.
+
+	Not more than maxleases can be outstanding at any time. A lease can
+	no more than self._duration seconds; it must either be released in
+	that period, renewed, or it will expire automatically.
+
+	The leases are given on a per-client basis. Once a client is
+	approved a lease, it will be automatically approved for any
+	subsequent requests as long as the lease does not expire (with each
+	subsequent request renewing the lease).
+
+	"""
 	def __init__(self, maxleases):
-		self._lock = threading.Lock()
-		self._leases = threading.BoundedSemaphore(maxleases)
-		self._leases_expire = dict()
 		self._maxleases = maxleases
 
-		self._lease_expiration_thread = threading.Thread(target=self._expire_leases)
-		self._lease_expiration_thread.daemon = True
-		self._lease_expiration_thread.start()
+		self._lock = threading.Lock()
+		self._leases_available = threading.BoundedSemaphore(maxleases)
+		self._active_leases = {}	# client -> (expires, [list of leased files])
+		self._duration = 10		# lease duration (in seconds)
+
+		th = threading.Thread(target=self._expire_leases_thread)
+		th.daemon = True
+		th.start()
 
 		logger.info("AccessSync manager started, maxleases=%d" % (self._maxleases,))
 
-	def obtain_access_lease(self, fn, _context):
+	def obtain_file_lease(self, fn, _context):
 		cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
-		logger.info("[%s] [AccessSync] requested lease for %s" % (cli_info, fn))
+		logger.debug("[%s] [AccessSync] requested lease for %s" % (cli_info, digest(fn)))
 
-		self._leases.acquire()
-		with self._lock:
-			self._leases_expire[_context.client_address] = time.time() + 10
-
-		logger.info("[%s] [AccessSync] acquired lease for %s" % (cli_info, fn))
-		return True
-
-	def relinquish_access_lease(self, fn, _context):
+		cli = _context.client_address
 		with self._lock:
 			try:
-				del self._leases_expire[_context.client_address]
-				self._leases.release()
+				(expires, files) = self._active_leases[cli]
+				files.append(fn)
+				self._active_leases[cli] = (time.time() + self._duration, files)
+
+				logger.debug("[%s] [AccessSync] lease extended for %s" % (cli_info, digest(fn)))
+				return True
 			except KeyError:
 				pass
 
-		cli_info = "%s:%s %s" % (_context.client_address + (_context.creds.user, ))
-		logger.info("[%s] [AccessSync] released lease for %s" % (cli_info, fn))
+		# Acquire a lease
+		self._leases_available.acquire()
+
+		# Record it
+		with self._lock:
+			assert cli not in self._active_leases
+			self._active_leases[cli] = (time.time() + self._duration, [fn])
+			##assert self._leases_available._initial_value - self._leases_available._Semaphore__value == len(self._active_leases)
+
+		logger.debug("[%s] [AccessSync] acquired lease for %s (%d active leases)" % (cli_info, digest(fn), len(self._active_leases)))
+		return True
+
+	def release_file_lease(self, fn, _context):
+		cli = _context.client_address
+		with self._lock:
+			try:
+				(expires, files) = self._active_leases[cli]
+
+				if fn is not None:
+					files.remove(fn)
+				else:
+					del files[:]
+
+				if len(files) == 0:
+					del self._active_leases[cli]
+					self._leases_available.release()
+					##assert self._leases_available._initial_value - self._leases_available._Semaphore__value == len(self._active_leases)
+
+				logger.debug("[%s:%s %s] [AccessSync] released lease for %s (%d active leases)" % (cli[0], cli[1], _context.creds.user, digest(fn), len(self._active_leases)))
+			except KeyError:
+				logger.debug("[%s:%s %s] [AccessSync] tried to release expired lease for %s (%d active leases)" % (cli[0], cli[1], _context.creds.user, digest(fn), len(self._active_leases)))
+				pass
 
 		return True
 
 	def __disconnect__(self, _context):
-		self.relinquish_access_lease(None, _context)
+		if _context.client_address in self._active_leases:
+			self.release_file_lease(None, _context)
 
-	def _expire_leases(self):
+	def _expire_leases_thread(self):
 		while True:
 			with self._lock:
 				t = time.time()
-				for lease, exptime in self._leases_expire.items():
-					if exptime > t:
-						continue
-					self._leases.release()
-					del self._leases_expire[lease]
+				for cli, (exptime, files) in self._active_leases.items():
+					if exptime < t:
+						del self._active_leases[cli]
+						self._leases_available.release()
+						##assert self._leases_available._initial_value - self._leases_available._Semaphore__value == len(self._active_leases)
+						logger.debug("[global] [AccessSync] expired lease for %s (%d active leases)" % (cli, len(self._active_leases)))
 			time.sleep(1)
 
 def usage():
 	print "Usage: %s --quiet <max_cores>" % sys.argv[0]
 
 if __name__ == "__main__":
-	optlist, (max_cores,) = tui_getopt('q', ['quiet'], 1, usage, stdopts=False)
+	optlist, (max_cores, max_leases) = tui_getopt('q', ['quiet'], 2, usage, stdopts=False)
 
 	# Instantiate a server
 	server = PyRPCServer("localhost", 9030)
 	server.register_instance(AllowAllAccessControl())
 	server.register_instance(WorkerManager(int(max_cores)))
-	server.register_instance(AccessSync(1))
+	server.register_instance(AccessSync(int(max_leases)))
 	server.serve_forever()

--- a/src/lsd/join_ops.py
+++ b/src/lsd/join_ops.py
@@ -1029,7 +1029,7 @@ class IntoWriter(object):
 
 	#################
 
-	def peek(self, rows):
+	def peek(self):
 		# We always return uint64 arrays
 		return np.empty(0, dtype='u8')
 

--- a/src/lsd/join_ops.py
+++ b/src/lsd/join_ops.py
@@ -1710,7 +1710,8 @@ class DB(object):
 			# Otherwise, import everything into top-level namespace
 			try:
 				lname = m.__lsd_name__
-				udf_dest = utils.Namespace(lname)
+				udf_dest = utils.Namespace()
+				setattr(udf_dest, '__name__', lname)
 				setattr(target, lname, udf_dest)
 			except AttributeError:
 				udf_dest = target
@@ -1723,7 +1724,8 @@ class DB(object):
 				setattr(udf_dest, name, item)
 
 		# Create a new module namespace
-		udfs = utils.Namespace('udfs')
+		udfs = utils.Namespace()
+		setattr(udfs, '__name__', 'udfs')
 
 		# Load UDFs from the paths in reverse, so newer overwrite older
 		for path in reversed(pathlist):

--- a/src/lsd/pool2.py
+++ b/src/lsd/pool2.py
@@ -2,7 +2,7 @@
 
 from multiprocessing import Process, Queue, cpu_count, current_process
 import threading
-from pyrpc import PyRPCProxy, RPCError
+from . import pyrpc
 from Queue import Empty
 from collections import defaultdict
 import socket
@@ -320,21 +320,6 @@ class Pool:
 
 		self._ntarget = self.nworkers
 
-	_ntarget_time = 0	# Last time _ntarget was refreshed
-	_ntarget = None		# Target number of active workers
-	def get_active_workers_target(self, _mgr):
-		""" Return the target number of active workers """
-		if time.time() - self._ntarget_time > 30:
-			try:
-				self._ntarget = min(_mgr.nworkers(), self.nworkers)
-			except RPCError:
-				_mgr._close()
-				logger.warning("Error contacting lsd-manager. Cannot coordinate resource usage with others, using %d cores." % self._ntarget)
-				pass
-			self._ntarget_time = time.time()
-
-		return self._ntarget
-
 	def imap_unordered(self, input, mapper, mapper_args=(), progress_callback=None, progress_callback_stage='map'):
 		""" Execute in parallel a callable <mapper> on all values of
 		    iterable <input>, ensuring that no more than ~nworkers
@@ -356,19 +341,27 @@ class Pool:
 		# Dispatch/execute
 		if parallel:
 			try:
+				# Connection to lsd-manager, with fallback if it fails
+				class Defaults(object):
+					def __init__(self, user, nworkers):
+						self._user = user
+						self._nworkers = nworkers
+
+					def _startup(self, p):
+						p.login(self._user);
+						p.register_workers(self._nworkers)
+
+					def nworkers(self):
+						return self._nworkers
+				_mgr = pyrpc.CachingProxy("localhost", 9030, cache_for=10, defaults=Defaults(getpass.getuser(), self.nworkers))
+
 				# Create workers (if not created already)
-				_mgr = PyRPCProxy("localhost", 9030)
-				def post_connect(self, user=getpass.getuser(), nworkers=self.nworkers):
-					# Called every time we (re)connect
-					self.login(user);
-					self.register_workers(nworkers)
-				_mgr._post_connect = post_connect.__get__(_mgr, _mgr.__class__) # See http://stackoverflow.com/questions/962962/python-changing-methods-and-attributes-at-runtime about this idiom
 				self._create_workers()
 
 				# Connect to worker manager and stop workers over the limit
 				stopped   = set()				# Idents of stopped workers
 				nrunning  = self.nworkers			# Number of running workers
-				ntarget   = self.get_active_workers_target(_mgr)# Desired number of running workers
+				ntarget   = min(_mgr.nworkers(), self.nworkers) # Desired number of running workers
 				nstopping = self.nworkers - ntarget		# Number of workers to which the stop command has been sent
 				for _ in xrange(nstopping):
 					self.qbroadcast.put( ('STOP', None) )
@@ -419,7 +412,7 @@ class Pool:
 					# Adjust the number of active workers
 					#
 					if k != n:
-						ntarget = self.get_active_workers_target(_mgr)
+						ntarget = min(_mgr.nworkers(), self.nworkers)
 					else:
 						# If all items have been exhausted, unstop all workers so they can
 						# finish cleanly

--- a/src/lsd/tui.py
+++ b/src/lsd/tui.py
@@ -95,7 +95,7 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: ERROR
+    level: INFO
     formatter: simple
     stream: ext://sys.stderr
   file:

--- a/src/lsd/tui.py
+++ b/src/lsd/tui.py
@@ -95,7 +95,7 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: INFO
+    level: WARNING
     formatter: simple
     stream: ext://sys.stderr
   file:

--- a/src/lsd/utils.py
+++ b/src/lsd/utils.py
@@ -8,8 +8,9 @@ class NamedList(list):
 		list.__init__(self, [ col for _, col in items ])
 
 class Namespace:
-	def __init__(self, name=''):
-		self.__name__ = name
+	def __init__(self, **kwargs):
+		for k, v in kwargs.iteritems():
+			setattr(self, k, v)
 
 class ModuleProxy(object):
 	""" A proxy class used to wrap modules imported as UDFs


### PR DESCRIPTION
peek() is called without arguments (e.g., self.qwriter.peek()) and does not use rows, so an error results when rows is specified as an argument.