### PR TITLE
Add scipy.spatial.cKDTree as an alternative to scikits.ann.kdtree.

### DIFF
--- a/src/lsd/join_ops.py
+++ b/src/lsd/join_ops.py
@@ -501,7 +501,7 @@ class CrossmatchJoin(JoinRelation):
 		# Cross-match, R x S
 		# Return objects (== rows) from S that are nearest neighbors of
 		# objects (== rows) in R
-		from scikits.ann import kdtree
+		import kdtree_wrapper
 		from utils import gnomonic, gc_dist
 
 		join = ColGroup(dtype=[('m1', 'u8'), ('m2', 'u8'), ('_DIST', 'f4'), ('_NR', 'u1')])
@@ -529,8 +529,9 @@ class CrossmatchJoin(JoinRelation):
 
 			# Construct kD-tree to find nearest neighbors from tableS
 			# for every object in tableR
-			tree = kdtree(xy2)
-			match_idxs, match_d2 = tree.knn(xy1, min(self.n, len(xy2)))
+			tree = kdtree_wrapper.kdtree(xy2)
+			num_nn = min(self.n, len(xy2))
+			match_idxs, match_d2 = kdtree_wrapper.query(tree, xy1, num_nn)
 			del tree
 
 			# Expand the matches into a table, with one row per neighbor

--- a/src/lsd/kdtree_wrapper.py
+++ b/src/lsd/kdtree_wrapper.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+try:
+    from scikits.ann import kdtree
+
+    def query(tree, xy1, num_nn):
+        return tree.knn(xy1, num_nn)
+
+except ImportError:
+    from scipy.spatial import cKDTree as kdtree
+
+    def query(tree, xy1, num_nn):
+        match_d2, match_idxs = tree.query(xy1, k=num_nn)
+        match_d2 = match_d2**2.
+        if num_nn == 1:
+            match_d2 = match_d2[..., np.newaxis]
+            match_idxs = match_idxs[..., np.newaxis]
+        return (match_idxs, match_d2)

--- a/src/lsd/smf.py
+++ b/src/lsd/smf.py
@@ -918,7 +918,7 @@ def _obj_det_match(cells, db, obj_tabname, det_tabname, o2d_tabname, radius, exp
 	   	Implement a consistency check to verify that.
 	"""
 
-	from scikits.ann import kdtree
+	import kdtree_wrapper
 
 	# Input is a tuple of obj_cell, and det_cells falling under that obj_cell
 	obj_cell, det_cells = cells
@@ -1005,8 +1005,8 @@ def _obj_det_match(cells, db, obj_tabname, det_tabname, o2d_tabname, radius, exp
 				if tree is None or nobj_old != len(xyobj):
 					del tree
 					nobj_old = len(xyobj)
-					tree = kdtree(xyobj)
-				match_idx, match_d2 = tree.knn(xydet, 1)
+					tree = kdtree_wrapper.kdtree(xyobj)
+				match_idx, match_d2 = kdtree_wrapper.query(tree, xydet, 1)
 				match_idx = match_idx[:,0]		# First neighbor only
 
 				####

--- a/src/lsd/tasks.py
+++ b/src/lsd/tasks.py
@@ -165,7 +165,7 @@ def _xmatch_mapper(qresult, tabname_to, radius, tabname_xm, n_neighbors):
 	    	- load all objects in tabname_to (including neighbors), make an ANN tree, find matches
 	    	- store the output into an index table
 	"""
-	from scikits.ann import kdtree
+	import kdtree_wrapper
 
 	db       = qresult.db
 	pix      = qresult.pix
@@ -190,8 +190,8 @@ def _xmatch_mapper(qresult, tabname_to, radius, tabname_xm, n_neighbors):
 
 			# Construct kD-tree to find an object in table_to that is nearest
 			# to an object in table_from, for every object in table_from
-			tree = kdtree(xy2)
-			match_idxs, match_d2 = tree.knn(xy1, min(n_neighbors, len(xy2)))
+			tree = kdtree_wrapper.kdtree(xy2)
+			match_idxs, match_d2 = kdtree_wrapper.query(tree, xy1, min(n_neighbors, len(xy2)))
 			del tree
 
 			# Create the index table array


### PR DESCRIPTION
scipy.spatial.cKDTree is a near drop-in replacement for scikits.ann.kdtree, and is a more ubiquitous dependency.  My quick tests did find that scipy.spatial.kdtree.query() was 3x slower than scikits.ann.knn(), so that's a concern---though on "real life" queries I looked at the match time was a small fraction of the total compute time.  The scipy kdtree introduced a ~5% performance regression.
